### PR TITLE
fix: use fixed date for sitemap lastModified

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -6,7 +6,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
   return [
     {
       url: "https://www.tomaszalesak.eu",
-      lastModified: new Date(),
+      lastModified: new Date("2026-03-24"),
       changeFrequency: "monthly",
       priority: 1,
     },


### PR DESCRIPTION
## Summary
- Replaces `new Date()` with a fixed date (`2026-03-24`) in `sitemap.ts` to prevent the sitemap `lastModified` value from changing on every build, which caused unnecessary cache invalidation.

Closes #6