### PR TITLE
fix: match image dimensions to rendered size in hero

### DIFF
--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -7,8 +7,8 @@ export function Hero() {
       <Image
         src="/portrait.webp"
         alt="Tomáš Zálešák"
-        width={200}
-        height={200}
+        width={100}
+        height={100}
         className="rounded-full w-[100px] h-[100px]"
         priority
       />


### PR DESCRIPTION
## Summary
- Changed `width` and `height` props on the hero portrait `<Image>` from `200` to `100` to match the CSS-rendered size (`w-[100px] h-[100px]`), eliminating unnecessary downscaling by the browser.

Closes #5