### PR TITLE
fix: add aria-labelledby to section components

### DIFF
--- a/src/components/section.tsx
+++ b/src/components/section.tsx
@@ -1,3 +1,4 @@
+import { useId } from "react";
 import { Box, Heading } from "@radix-ui/themes";
 
 interface SectionProps {
@@ -6,10 +7,11 @@ interface SectionProps {
 }
 
 export function Section({ title, children }: SectionProps) {
+  const headingId = useId();
   return (
     <Box asChild mt="7">
-      <section>
-        <Heading as="h2" size="5" mb="3">
+      <section aria-labelledby={headingId}>
+        <Heading as="h2" size="5" mb="3" id={headingId}>
           {title}
         </Heading>
         {children}

--- a/src/components/section.tsx
+++ b/src/components/section.tsx
@@ -1,5 +1,5 @@
-import { useId } from "react";
 import { Box, Heading } from "@radix-ui/themes";
+import { useId } from "react";
 
 interface SectionProps {
   title: string;


### PR DESCRIPTION
## Summary
- Adds `aria-labelledby` to `<section>` elements in the reusable `Section` component, linking each section to its heading via `useId()`.
- Improves screen reader navigation by allowing assistive technology to announce the section name.

Closes #8

## Test plan
- [ ] Verify the site builds without errors (`bun run build`)
- [ ] Inspect rendered HTML to confirm each `<section>` has `aria-labelledby` matching its `<h2>` id
- [ ] Test with a screen reader to confirm sections are announced by their heading