### PR TITLE
fix: remove redundant image preload link

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -72,12 +72,6 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
-        <link
-          rel="preload"
-          href="/portrait.webp"
-          as="image"
-          type="image/webp"
-        />
         <meta
           name="theme-color"
           content="#ffffff"


### PR DESCRIPTION
## Summary
- Remove the manual `<link rel="preload">` for `/portrait.webp` in `layout.tsx`
- The Next.js `priority` prop on the `<Image>` component in `hero.tsx` already injects an equivalent preload link automatically

Closes #11