### PR TITLE
fix: improve accessibility of company separators

### DIFF
--- a/src/components/experience.tsx
+++ b/src/components/experience.tsx
@@ -21,18 +21,24 @@ export function Experience() {
               {job.description}
             </Text>
             <Box mt="2">
-              <Flex gap="2" wrap="wrap" align="center">
+              <Flex
+                gap="1"
+                wrap="wrap"
+                align="center"
+                role="list"
+                aria-label="Companies"
+              >
                 {job.companies.map((company, i) => (
-                  <span key={company.name}>
+                  <li key={company.name} className="list-none">
                     <ExternalLink href={company.url} size="2" weight="medium">
                       {company.name}
                     </ExternalLink>
                     {i < job.companies.length - 1 && (
-                      <Text color="gray" size="2">
+                      <Text color="gray" size="2" aria-hidden="true">
                         {" · "}
                       </Text>
                     )}
-                  </span>
+                  </li>
                 ))}
               </Flex>
             </Box>


### PR DESCRIPTION
## Summary
- Add `aria-hidden="true"` to visual dot separators so screen readers skip them
- Add semantic list roles (`role="list"` on container, `<li>` for items) with `aria-label="Companies"`
- Reduce gap from `2` to `1` for tighter spacing with separators

Closes #7

## Test plan
- [ ] Verify company links still render with dot separators between them
- [ ] Test with a screen reader to confirm separators are not announced
- [ ] Confirm lint and build pass