### PR TITLE
fix: add worksFor to JSON-LD Person schema

### DIFF
--- a/src/components/json-ld.tsx
+++ b/src/components/json-ld.tsx
@@ -8,6 +8,11 @@ export function JsonLd() {
     url: "https://www.tomaszalesak.eu",
     email: "tomas@tomaszalesak.eu",
     jobTitle: "Senior Software Engineer",
+    worksFor: {
+      "@type": "Organization",
+      name: "Disruptive Lab",
+      url: "https://disruptivelab.dev/",
+    },
     sameAs: [
       "https://www.linkedin.com/in/zalesaktomas/",
       "https://github.com/tomaszalesak",


### PR DESCRIPTION
## Summary
- Adds `worksFor` property (Disruptive Lab) to the JSON-LD Person schema in `json-ld.tsx`
- Improves structured data for richer search result snippets

## Test plan
- [ ] Verify lint and type check pass in CI
- [ ] Validate updated JSON-LD output with Google Rich Results Test

Closes #12