### PR TITLE
feat: add CV download link to contact section

### DIFF
--- a/src/data/content.ts
+++ b/src/data/content.ts
@@ -50,6 +50,12 @@ export const contactLinks: ContactLink[] = [
     text: "facebook.com/zalesak.tomas",
     external: true,
   },
+  {
+    label: "CV",
+    href: "/cv.pdf",
+    text: "Download CV (PDF)",
+    external: false,
+  },
 ];
 
 export const workExperience: WorkExperience[] = [


### PR DESCRIPTION
## Summary
- Adds a "CV" row to the contact links table with a download link to `/cv.pdf`
- The PDF is already present in `public/` and served as a static file

## Test plan
- [ ] Verify the CV row appears as the last entry in the Contact section
- [ ] Verify clicking the link downloads/opens the PDF

Closes #10