### PR TITLE
chore: enable stricter Biome lint rules

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -15,7 +15,15 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true
+      "recommended": true,
+      "correctness": {
+        "noUnusedVariables": "error",
+        "noUnusedImports": "error"
+      },
+      "style": {
+        "noNonNullAssertion": "warn",
+        "useConst": "error"
+      }
     }
   },
   "javascript": {


### PR DESCRIPTION
## Summary
- Add stricter Biome lint rules: `noUnusedVariables`, `noUnusedImports`, `useConst` (all `error`), and `noNonNullAssertion` (`warn`).
- All existing code passes the new rules with no changes needed.

Closes #13