### PR TITLE
refactor: extract site URL into shared constant

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,9 +1,8 @@
 import { Container, Theme } from "@radix-ui/themes";
 import type { Metadata } from "next";
 import { ThemeProvider } from "next-themes";
+import { siteUrl } from "@/data/content";
 import "./globals.css";
-
-const siteUrl = "https://www.tomaszalesak.eu";
 
 export const metadata: Metadata = {
   metadataBase: new URL(siteUrl),

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,11 +1,12 @@
 import type { MetadataRoute } from "next";
+import { siteUrl } from "@/data/content";
 
 export const dynamic = "force-static";
 
 export default function sitemap(): MetadataRoute.Sitemap {
   return [
     {
-      url: "https://www.tomaszalesak.eu",
+      url: siteUrl,
       lastModified: new Date("2026-03-24"),
       changeFrequency: "monthly",
       priority: 1,

--- a/src/components/json-ld.tsx
+++ b/src/components/json-ld.tsx
@@ -1,11 +1,12 @@
 import type { Person, WithContext } from "schema-dts";
+import { siteUrl } from "@/data/content";
 
 export function JsonLd() {
   const jsonLd: WithContext<Person> = {
     "@context": "https://schema.org",
     "@type": "Person",
     name: "Tomáš Zálešák",
-    url: "https://www.tomaszalesak.eu",
+    url: siteUrl,
     email: "tomas@tomaszalesak.eu",
     jobTitle: "Senior Software Engineer",
     worksFor: {
@@ -40,7 +41,7 @@ export function JsonLd() {
       "Azure",
       "AWS",
     ],
-    image: "https://www.tomaszalesak.eu/portrait.webp",
+    image: `${siteUrl}/portrait.webp`,
   };
 
   return (

--- a/src/data/content.ts
+++ b/src/data/content.ts
@@ -1,3 +1,5 @@
+export const siteUrl = "https://www.tomaszalesak.eu";
+
 export interface ContactLink {
   label: string;
   href: string;


### PR DESCRIPTION
## Summary
- Added `export const siteUrl` to `src/data/content.ts` as the single source of truth for the domain
- Updated `src/app/layout.tsx`, `src/app/sitemap.ts`, and `src/components/json-ld.tsx` to import from there instead of hardcoding the URL

Closes #9

## Test plan
- [x] Biome lint passes
- [x] Build succeeds (`bun run build`)
- [ ] CI passes on the PR