### PR TITLE
Fix: update AutoCont title to Software Engineer Intern

### DIFF
--- a/src/data/content.ts
+++ b/src/data/content.ts
@@ -73,7 +73,7 @@ export const workExperience: WorkExperience[] = [
     period: "2019–2021",
   },
   {
-    title: "Software Engineer",
+    title: "Software Engineer Intern",
     description:
       "Localization automation, translating and database migration, Python 3, SQL, .NET, JavaScript.",
     companies: [{ name: "AutoCont", url: "https://www.autocont.cz/" }],


### PR DESCRIPTION
## Summary
- Updated AutoCont role title from "Software Engineer" to "Software Engineer Intern" to match the CV

## Test plan
- Verify the experience section shows "Software Engineer Intern" for the AutoCont entry

Closes #4