### PR TITLE
fix: use git commit date for sitemap lastModified

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,13 +1,18 @@
+import { execSync } from "node:child_process";
 import type { MetadataRoute } from "next";
 import { siteUrl } from "@/data/content";
 
 export const dynamic = "force-static";
 
+const lastCommitDate = new Date(
+  execSync("git log -1 --format=%cI").toString().trim(),
+);
+
 export default function sitemap(): MetadataRoute.Sitemap {
   return [
     {
       url: siteUrl,
-      lastModified: new Date("2026-03-24"),
+      lastModified: lastCommitDate,
       changeFrequency: "monthly",
       priority: 1,
     },


### PR DESCRIPTION
## Summary
- Replaces hardcoded `new Date("2026-03-24")` with `execSync("git log -1 --format=%cI")` to automatically use the last git commit timestamp
- Sitemap date stays accurate without manual updates on each deploy

## Test plan
- Build passes, `out/sitemap.xml` contains the correct last commit date

Updates #6