### PR TITLE
fix: list-semantics hydration error + major dependency bumps

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,15 +12,15 @@
         "react-dom": "19.2.7",
       },
       "devDependencies": {
-        "@biomejs/biome": "^2.4.2",
-        "@tailwindcss/postcss": "^4.1.18",
-        "@types/node": "^25.2.3",
-        "@types/react": "^19.2.14",
+        "@biomejs/biome": "^2.4.16",
+        "@tailwindcss/postcss": "^4.3.0",
+        "@types/node": "^25.9.3",
+        "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
         "critters": "^0.0.25",
-        "schema-dts": "^1.1.5",
-        "tailwindcss": "^4.1.18",
-        "typescript": "^5.9.3",
+        "schema-dts": "^2.0.0",
+        "tailwindcss": "^4.3.0",
+        "typescript": "^6.0.3",
       },
     },
   },
@@ -406,7 +406,9 @@
 
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
-    "schema-dts": ["schema-dts@1.1.5", "", {}, "sha512-RJr9EaCmsLzBX2NDiO5Z3ux2BVosNZN5jo0gWgsyKvxKIUL5R3swNvoorulAeL9kLB0iTSX7V6aokhla2m7xbg=="],
+    "schema-dts": ["schema-dts@2.0.0", "", { "dependencies": { "schema-dts-lib": "^1.0.0" } }, "sha512-t7NoCy3Rn5GHGx6p7s1qIYK/AeIb8ZxJNR9WUNFkwMv2CiiGZBmqqYWc2FlZVm5ZbiHMY4OvBWhj7QtyrFO2Jw=="],
+
+    "schema-dts-lib": ["schema-dts-lib@1.0.0", "", { "peerDependencies": { "typescript": ">=4.9.5" } }, "sha512-9MEO5vpQH9JdBioUupqluzxSYxPLjhmqRUudk15adUl/ypnRsM2/M1kN3AmVJQeG7nZqcL68H8JlGqQQT6vy9A=="],
 
     "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
@@ -424,7 +426,7 @@
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
-    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
     "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
 

--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "critters": "^0.0.25",
-    "schema-dts": "^1.1.5",
+    "schema-dts": "^2.0.0",
     "tailwindcss": "^4.3.0",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   },
   "ignoreScripts": [
     "sharp",

--- a/src/components/experience.tsx
+++ b/src/components/experience.tsx
@@ -22,71 +22,67 @@ export function Experience() {
             </Text>
             {job.companies && (
               <Box mt="2">
-                <Flex
-                  gap="1"
-                  wrap="wrap"
-                  align="center"
-                  role="list"
-                  aria-label="Companies"
-                >
-                  {job.companies.map((company, i) => (
-                    <li key={company.name} className="list-none">
-                      <ExternalLink href={company.url} size="2" weight="medium">
-                        {company.name}
-                      </ExternalLink>
-                      {i < (job.companies?.length ?? 0) - 1 && (
-                        <Text color="gray" size="2" aria-hidden="true">
-                          {" · "}
-                        </Text>
-                      )}
-                    </li>
-                  ))}
+                <Flex gap="1" wrap="wrap" align="center" asChild>
+                  <ul aria-label="Companies" className="list-none">
+                    {job.companies.map((company, i) => (
+                      <li key={company.name}>
+                        <ExternalLink
+                          href={company.url}
+                          size="2"
+                          weight="medium"
+                        >
+                          {company.name}
+                        </ExternalLink>
+                        {i < (job.companies?.length ?? 0) - 1 && (
+                          <Text color="gray" size="2" aria-hidden="true">
+                            {" · "}
+                          </Text>
+                        )}
+                      </li>
+                    ))}
+                  </ul>
                 </Flex>
               </Box>
             )}
             {job.projects && (
-              <Flex
-                direction="column"
-                gap="3"
-                mt="3"
-                role="list"
-                aria-label="Client projects"
-              >
-                {job.projects.map((project) => (
-                  <li
-                    key={project.name}
-                    className="list-none border-l-2 border-(--gray-a6) pl-3"
-                  >
-                    <Heading as="h4" size="2">
-                      <ExternalLink
-                        href={project.url}
-                        highContrast
-                        underline="hover"
-                      >
-                        {project.name}
-                      </ExternalLink>
-                    </Heading>
-                    <Text as="p" size="2" color="gray" mt="1">
-                      {project.description}
-                    </Text>
-                    <Box mt="2">
-                      <Flex
-                        gap="1"
-                        wrap="wrap"
-                        role="list"
-                        aria-label="Technologies used"
-                      >
-                        {project.technologies.map((tech) => (
-                          <li key={tech} className="list-none">
-                            <Badge variant="soft" size="1">
-                              {tech}
-                            </Badge>
-                          </li>
-                        ))}
-                      </Flex>
-                    </Box>
-                  </li>
-                ))}
+              <Flex direction="column" gap="3" mt="3" asChild>
+                <ul aria-label="Client projects" className="list-none">
+                  {job.projects.map((project) => (
+                    <li
+                      key={project.name}
+                      className="border-l-2 border-(--gray-a6) pl-3"
+                    >
+                      <Heading as="h4" size="2">
+                        <ExternalLink
+                          href={project.url}
+                          highContrast
+                          underline="hover"
+                        >
+                          {project.name}
+                        </ExternalLink>
+                      </Heading>
+                      <Text as="p" size="2" color="gray" mt="1">
+                        {project.description}
+                      </Text>
+                      <Box mt="2">
+                        <Flex gap="1" wrap="wrap" asChild>
+                          <ul
+                            aria-label="Technologies used"
+                            className="list-none"
+                          >
+                            {project.technologies.map((tech) => (
+                              <li key={tech}>
+                                <Badge variant="soft" size="1">
+                                  {tech}
+                                </Badge>
+                              </li>
+                            ))}
+                          </ul>
+                        </Flex>
+                      </Box>
+                    </li>
+                  ))}
+                </ul>
               </Flex>
             )}
           </Card>


### PR DESCRIPTION
Closes #28

## Hydration fix
`experience.tsx` rendered client-project and technology items as bare `<li>` inside `<div role="list">` (Radix `Flex`). That nested a technology `<li>` inside a project `<li>` — invalid HTML — producing `<li> cannot be a descendant of <li>` and a hydration mismatch in `bun run dev`.

Now uses real `<ul>`/`<li>` via `Flex asChild`. A `<ul>` nested in a `<li>` is valid HTML, so the browser no longer restructures the DOM and server/client markup match. This also satisfies SonarLint S6819 ("use `<li>` instead of role=listitem") and avoids Biome's redundant-role rule (no `role="list"` on the `<ul>`).

## Major dependency bumps
The two majors held back from #27:
- TypeScript 5.9.3 → 6.0.3
- schema-dts 1.1.5 → 2.0.0

`tsc --noEmit`, `bun run lint`, and `bun run build` all pass; the JSON-LD types resolve cleanly under schema-dts 2.

## Verification
- Build output has valid `<ul>`/`<li>` nesting (technologies `<ul>` inside each project `<li>`), zero `role="list"` remaining
- Lint, type-check, and static export all green