### PR TITLE
fix(mobile): hero badge overflow + readability

### DIFF
--- a/src/components/education.tsx
+++ b/src/components/education.tsx
@@ -17,12 +17,12 @@ export function Education() {
                 <Flex gap="2" align="center" mt="1">
                   <ExternalLink
                     href={entry.institutionUrl}
-                    size="2"
+                    size={{ initial: "3", sm: "2" }}
                     weight="medium"
                   >
                     {entry.institution}
                   </ExternalLink>
-                  <Text size="2" color="gray">
+                  <Text size={{ initial: "3", sm: "2" }} color="gray">
                     · {entry.degree}
                   </Text>
                 </Flex>

--- a/src/components/experience.tsx
+++ b/src/components/experience.tsx
@@ -17,7 +17,7 @@ export function Experience() {
                 {job.period}
               </Badge>
             </Flex>
-            <Text as="p" size="2" color="gray" mt="2">
+            <Text as="p" size={{ initial: "3", sm: "2" }} color="gray" mt="2">
               {job.description}
             </Text>
             {job.companies && (
@@ -52,7 +52,7 @@ export function Experience() {
                       key={project.name}
                       className="border-l-2 border-(--gray-a6) pl-3"
                     >
-                      <Heading as="h4" size="2">
+                      <Heading as="h4" size={{ initial: "3", sm: "2" }}>
                         <ExternalLink
                           href={project.url}
                           highContrast
@@ -61,7 +61,12 @@ export function Experience() {
                           {project.name}
                         </ExternalLink>
                       </Heading>
-                      <Text as="p" size="2" color="gray" mt="1">
+                      <Text
+                        as="p"
+                        size={{ initial: "3", sm: "2" }}
+                        color="gray"
+                        mt="1"
+                      >
                         {project.description}
                       </Text>
                       <Box mt="2">
@@ -72,7 +77,10 @@ export function Experience() {
                           >
                             {project.technologies.map((tech) => (
                               <li key={tech}>
-                                <Badge variant="soft" size="1">
+                                <Badge
+                                  variant="soft"
+                                  size={{ initial: "2", sm: "1" }}
+                                >
                                   {tech}
                                 </Badge>
                               </li>

--- a/src/components/expertise.tsx
+++ b/src/components/expertise.tsx
@@ -27,7 +27,7 @@ const techRows: { label: string; items: string; color: AccentColor }[] = [
 
 function Eyebrow({ children, mt }: Readonly<{ children: string; mt?: "6" }>) {
   return (
-    <Heading as="h3" size="2" mb="3" mt={mt}>
+    <Heading as="h3" size={{ initial: "3", sm: "2" }} mb="3" mt={mt}>
       {children}
     </Heading>
   );
@@ -36,27 +36,27 @@ function Eyebrow({ children, mt }: Readonly<{ children: string; mt?: "6" }>) {
 export function Expertise() {
   return (
     <Section title="What I do">
-      <Text as="p" size="3">
+      <Text as="p" size={{ initial: "4", sm: "3" }}>
         {expertiseIntro}
       </Text>
 
       <Eyebrow mt="6">How I work</Eyebrow>
-      <Grid columns={{ initial: "1", xs: "2" }} gap="3">
+      <Grid columns={{ initial: "1", xs: "2" }} gap="4">
         {workPrinciples.map((principle) => (
           <Box
             key={principle.title}
-            className="rounded-lg p-3"
+            className="rounded-lg p-4"
             style={{ backgroundColor: token(principle.color, 2) }}
           >
-            <Flex align="center" gap="2" mb="1">
+            <Flex align="center" gap="2" mb="2">
               <span style={{ color: token(principle.color, 11) }}>
                 <PrincipleGlyph icon={principle.icon} />
               </span>
-              <Heading as="h4" size="2">
+              <Heading as="h4" size={{ initial: "3", sm: "2" }}>
                 {principle.title}
               </Heading>
             </Flex>
-            <Text as="p" size="2" color="gray">
+            <Text as="p" size={{ initial: "3", sm: "2" }} color="gray">
               {principle.description}
             </Text>
           </Box>
@@ -64,13 +64,13 @@ export function Expertise() {
       </Grid>
 
       <Eyebrow mt="6">Tech stack and what I can build for you</Eyebrow>
-      <Flex direction="column" gap="2">
+      <Flex direction="column" gap="3">
         {techRows.map((row) => (
           <Flex key={row.label} gap="2" align="baseline" wrap="wrap">
-            <Badge color={row.color} variant="soft" radius="full">
+            <Badge color={row.color} variant="soft" size="2" radius="full">
               {row.label}
             </Badge>
-            <Text size="2" color="gray">
+            <Text size={{ initial: "3", sm: "2" }} color="gray">
               {row.items}
             </Text>
           </Flex>

--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -5,37 +5,42 @@ import { contactLinks } from "@/data/content";
 export function Hero() {
   return (
     <Flex direction="column" gap="5">
-      <Flex align="center" gap="5">
+      <Flex align="center" gap="4">
         <Image
           src="/portrait.webp"
           alt="Tomáš Zálešák"
           width={100}
           height={100}
-          className="rounded-full w-25 h-25 ring-2 ring-(--gray-a5)"
+          className="rounded-full w-25 h-25 shrink-0 ring-2 ring-(--gray-a5)"
           priority
         />
         <div>
           <Heading as="h1" size={{ initial: "7", sm: "8" }}>
             Tomáš Zálešák
           </Heading>
-          <Text as="p" size="3" color="gray" mt="1">
+          <Text as="p" size={{ initial: "3", sm: "4" }} color="gray" mt="1">
             Senior software engineer based in the EU (CET).
           </Text>
-          <Badge color="green" variant="soft" size="2" mt="2">
-            <span
-              aria-hidden="true"
-              className="h-1.5 w-1.5 rounded-full bg-(--green-9)"
-            />
-            {"Open to new projects — feel free to reach out"}
-          </Badge>
         </div>
       </Flex>
+      <Badge
+        color="green"
+        variant="soft"
+        size="2"
+        className="w-fit whitespace-normal"
+      >
+        <span
+          aria-hidden="true"
+          className="h-1.5 w-1.5 shrink-0 rounded-full bg-(--green-9)"
+        />
+        {"Open to new projects — feel free to reach out"}
+      </Badge>
       <Flex gap="2" wrap="wrap">
         {contactLinks.map((link) => (
           <Button
             key={link.label}
             asChild
-            size="2"
+            size="3"
             variant={link.label === "Email" ? "solid" : "soft"}
           >
             {link.external ? (

--- a/src/components/hobbies.tsx
+++ b/src/components/hobbies.tsx
@@ -5,7 +5,7 @@ import { Section } from "./section";
 export function Hobbies() {
   return (
     <Section title="Hobbies">
-      <Text as="p" size="3">
+      <Text as="p" size={{ initial: "4", sm: "3" }}>
         Apart from IT, I love sports, especially basketball which I play for{" "}
         <ExternalLink href="http://basket.ub.cz">
           BK TJ Spartak Uherský Brod


### PR DESCRIPTION
Closes #30

On mobile the green availability badge overflowed the right edge of the screen (it lived in the narrow text column beside the portrait), and body text read small/cramped.

## Changes
- **Badge**: moved to its own full-width row below the name; `w-fit` keeps the pill its natural size, `whitespace-normal` wraps it instead of overflowing on very narrow phones.
- **Readability**: body text bumped one Radix step on mobile via responsive sizes (`{ initial: "3", sm: "2" }`; intro & hobbies `{ initial: "4", sm: "3" }`) — bigger text and looser line-height on phones, desktop unchanged.
- **Spacing**: principle tiles `p-3→p-4`, grid `gap-3→gap-4`, tech rows `gap-2→gap-3`, contact buttons `size-3`.

Touches hero, expertise, experience, education, hobbies. Lint, type-check, and build all pass.