### PR TITLE
chore: add Dependabot and refresh docs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,36 @@
+version: 2
+updates:
+  # JavaScript / TypeScript dependencies — updates package.json and bun.lock
+  # together (Dependabot's dedicated Bun ecosystem), so `bun install
+  # --frozen-lockfile` in CI stays in sync.
+  - package-ecosystem: "bun"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      # One PR per week for all non-major bumps; majors get their own PR so
+      # they can be reviewed and tested individually.
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # GitHub Actions pinned in the workflows (checkout, setup-bun, pages, …)
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ Single-page portfolio site built with Next.js 16, React 19, Radix UI Themes, and
 ### Key decisions
 
 - **Static export only** (`output: "export"` in next.config.ts) — no server-side features, no API routes. Images use `unoptimized: true`. Critical CSS is inlined via `experimental.optimizeCss` (critters).
-- **Content is data-driven** — all portfolio content lives in `src/data/content.ts` as typed data (`contactLinks`; `expertiseIntro`/`expertiseClosing`, `services`, `workPrinciples`, `skillGroups` — rendered together by the merged `Expertise` section, each carrying a Radix `AccentColor`; `clientProjects`, `workExperience` — which nests `clientProjects` under the freelance entry — and `education`) and the shared `siteUrl` constant. Components import from there. To update content, edit that file only. The `siteUrl` is also used by `layout.tsx`, `sitemap.ts`, and `json-ld.tsx`.
+- **Content is data-driven** — all portfolio content lives in `src/data/content.ts` as typed data (`contactLinks`; `expertiseIntro`, `services`, `workPrinciples`, `skillGroups` — rendered together by the merged `Expertise` section, each carrying a Radix `AccentColor`; `clientProjects`, `workExperience` — which nests `clientProjects` under the freelance entry — and `education`) and the shared `siteUrl` constant. Components import from there. To update content, edit that file only. The `siteUrl` is also used by `layout.tsx`, `sitemap.ts`, and `json-ld.tsx`.
 - **Theming uses three layers:** `next-themes` (sets `class="dark"/"light"` on `<html>`, system preference only), Radix UI `<Theme>` (reads the class to switch design tokens), and Tailwind v4 (supports `dark:` variants natively when class is set on `<html>`).
 - **CSS layering:** `globals.css` imports Radix styles into `layer(components)` so Tailwind utilities can override them.
 - **Tailwind v4** — CSS-first configuration via `@import "tailwindcss"` in `globals.css`, no `tailwind.config` file. PostCSS plugin in `postcss.config.mjs`.
@@ -38,17 +38,18 @@ src/
     sitemap.ts      — single-URL sitemap
   components/
     hero.tsx        — portrait, name, availability badge, contact buttons
-    expertise.tsx   — merged "What I do": intro, colored service cards,
-                      how-i-work principle tiles, tech-stack badges, closing
+    expertise.tsx   — merged "What I do": intro, "How I work" principle tiles,
+                      and "Tech stack and what I can build for you" badge rows
+                      (skill groups + services), all color-coded per AccentColor
     experience.tsx  — work experience cards with nested client projects
     education.tsx   — education cards
     hobbies.tsx     — hobbies paragraph
     section.tsx     — reusable section wrapper with heading
-    icons.tsx       — inline stroke icons (services, principles, checkmark)
+    icons.tsx       — inline stroke glyphs for the work principles
     external-link.tsx — accessible external link (target="_blank" + sr-only label)
     json-ld.tsx     — ProfilePage/Person schema (schema-dts)
   data/
-    content.ts      — all portfolio content as typed arrays
+    content.ts      — all portfolio content as typed data
 public/
     CNAME, favicons, portrait images, cv.pdf, site.webmanifest
 ```
@@ -58,3 +59,4 @@ public/
 - **CI** (`.github/workflows/ci.yml`): Runs on PRs to `main` and pushes to non-main branches. Steps: (conditional CV compile) → lint → type check (`tsc --noEmit`) → build.
 - **CD** (`.github/workflows/deploy.yml`): Runs on push to `main`. Steps: (conditional CV compile → `public/cv.pdf`) → install (`--frozen-lockfile`) → build → deploy `out/` to GitHub Pages. Custom domain: `www.tomaszalesak.eu` (CNAME in `public/`).
 - **CV build in CI/CD:** both workflows run `scripts/build-cv.sh` (the same Dockerized TeX Live build used locally) when `cv/*.tex` exists — deploy regenerates `public/cv.pdf`, CI validates the LaTeX compiles. If `cv/` has no `.tex`, the step skips and the committed `public/cv.pdf` is used, so the pipeline is safe even without the source.
+- **Dependency updates** (`.github/dependabot.yml`): Dependabot opens weekly PRs for two ecosystems — `bun` (updates `package.json` + `bun.lock` together, so `--frozen-lockfile` stays valid) and `github-actions` (the action pins in the workflows). Minor/patch bumps are grouped into a single PR; majors get individual PRs for review.

--- a/README.md
+++ b/README.md
@@ -14,17 +14,31 @@ Personal portfolio website for [Tomáš Zálešák](https://www.tomaszalesak.eu)
 
 ```bash
 bun install
-bun run dev
+bun run dev        # dev server
+bun run lint       # Biome check (use lint:fix to auto-fix)
+bun run build      # static export to out/
 ```
 
-## Build
+## CV
+
+The CV is a LaTeX ([moderncv](https://ctan.org/pkg/moderncv)) document in
+[`cv/`](cv/), compiled in a Dockerized TeX Live image — no local TeX install
+needed:
 
 ```bash
-bun run build
+bun run cv:build   # → public/cv.pdf (requires Docker)
 ```
 
-Static output is generated in the `out/` directory.
+See [`cv/README.md`](cv/README.md) for details.
 
 ## Deployment
 
-Deployed to [GitHub Pages](https://pages.github.com/) via GitHub Actions on push to `main`.
+Deployed to [GitHub Pages](https://pages.github.com/) via GitHub Actions on push
+to `main`. The deploy regenerates `public/cv.pdf` from the LaTeX source so the
+downloadable CV is always current.
+
+## Dependencies
+
+Kept up to date by [Dependabot](.github/dependabot.yml), which opens weekly
+grouped PRs for the Bun (`package.json` + `bun.lock`) and GitHub Actions
+dependencies.


### PR DESCRIPTION
Closes #34

Automates dependency upkeep and brings docs current.

## Dependabot (`.github/dependabot.yml`)
- **bun** ecosystem — updates `package.json` and `bun.lock` together (GA Feb 2025), so `bun install --frozen-lockfile` in CI stays in sync.
- **github-actions** — keeps the workflow action pins current.
- Weekly schedule; minor/patch grouped into a single PR; majors get individual PRs for review.

## Docs
- **README**: added a CV section (`bun run cv:build`, Docker, no local TeX) and a Dependencies section; listed the lint command.
- **CLAUDE.md**: documented Dependabot and fixed stale descriptions — `expertise.tsx` no longer has "service cards"/a "closing" (services are now badge rows), `icons.tsx` only has the principle glyphs, and removed the dangling `expertiseClosing` reference.

## Verification
- `dependabot.yml` validated (YAML + schema fields: version 2, two ecosystems, weekly, grouped).
- No stale references remain in the docs.